### PR TITLE
Changed table id to match partial/tabulator_js.xsl

### DIFF
--- a/xslt/offences.xsl
+++ b/xslt/offences.xsl
@@ -36,7 +36,7 @@
                             <xsl:value-of select="$doc_title"/>
                         </h1>
 
-                        <table class="table" id="offences">
+                        <table class="table" id="myTable">
                             <thead>
                                 <tr>
                                     <th scope="col" tabulator-headerFilter="input">Beschreibung</th>


### PR DESCRIPTION
offences.xsl generates a table with  id #offences, but the js's are expecting a table with id #myTable.